### PR TITLE
Format code in the same style as gofmt

### DIFF
--- a/day-01/hello.go
+++ b/day-01/hello.go
@@ -1,6 +1,6 @@
- /*
+/*
 	Day 1: Hello World
-	
+
   https://golang.org/dl/ : download and install golang for your OS
 
 	$ cd your/src/directory
@@ -8,8 +8,8 @@
 	$ cd learning-golang
 	$ vi hello.go            # copy and paste this code
 	$ go run hello.go        # run directly (doesn't create the compiled exec)
- */
- 
+*/
+
 package main
 
 import "fmt"

--- a/day-02/variables-functions.go
+++ b/day-02/variables-functions.go
@@ -8,7 +8,7 @@ $ vi variables-functions.go # copy this code here
 $ go run variables-functions.go
 */
 
-package main 
+package main
 
 import "fmt"
 

--- a/day-03/structs.go
+++ b/day-03/structs.go
@@ -14,27 +14,27 @@ import "fmt"
 
 // define a struct
 type rect struct {
-		width, height int
-		name string
+	width, height int
+	name          string
 }
 
 // define a method named perim() on rect type
 func (r *rect) perim() int {
-    return 2 * r.width + 2 * r.height
+	return 2*r.width + 2*r.height
 }
 
 // define another method
 func (r *rect) expand(i int) {
-  r.width *= i
-  r.height *= i
+	r.width *= i
+	r.height *= i
 }
 
 func main() {
 	// use {} notation to instantiate struct
 	var r = rect{
-		width: 20, 
-		height: 5, 
-		name: "bar", // <- yes, that comma is not a typo
+		width:  20,
+		height: 5,
+		name:   "bar", // <- yes, that comma is not a typo
 	}
 
 	fmt.Println("Perimiter:", r.perim())
@@ -48,7 +48,7 @@ EXPLANATION
 - If you want to logically group variables, you need to use structs
 - You can use above notation to define methods on structs
 - Note the named variable instead of the "this" keyword in such methods
-- By default, Go variables are always passed by value (i.e when you pass something 
+- By default, Go variables are always passed by value (i.e when you pass something
 	between functions, you're  passing copies)
 - If you want to reference the original object, you need to pass a pointer (*)
 - TRY: try removing the * from the expand method and see what happens!S

--- a/day-04/stdlib.go
+++ b/day-04/stdlib.go
@@ -11,25 +11,25 @@ $ go run stdlib.go
 package main
 
 import (
-  "fmt"
-	"net/http" 
+	"fmt"
 	"io/ioutil"
+	"net/http"
 )
 
 func main() {
-  var resp, err = http.Get("http://example.com/posts/1")
-  if err != nil {
-    fmt.Println("Unable to get from example.com")
-    return
+	var resp, err = http.Get("http://example.com/posts/1")
+	if err != nil {
+		fmt.Println("Unable to get from example.com")
+		return
 	}
 	defer resp.Body.Close()
 
-  body, err := ioutil.ReadAll(resp.Body)
-  if err != nil {
-    fmt.Println("Unable to read response from example.com")
-    return
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		fmt.Println("Unable to read response from example.com")
+		return
 	}
-  fmt.Println(string(body))
+	fmt.Println(string(body))
 }
 
 /*

--- a/day-05/packages.go
+++ b/day-05/packages.go
@@ -16,13 +16,13 @@ import "./util"
 import "fmt"
 
 func main() {
-  fact := util.Fact(5)
-  fmt.Println(fact)
+	fact := util.Fact(5)
+	fmt.Println(fact)
 }
 
 /*
 EXPLANATION
-- Think of a package as a collection of functions 
+- Think of a package as a collection of functions
 - A package named "util" must be in a directory named "util"
 - Package names are lowercase
 - Go has no public/private keyword, instead:

--- a/day-06/server.go
+++ b/day-06/server.go
@@ -21,8 +21,8 @@ import (
 func main() {
 	http.HandleFunc("/hello", func(w http.ResponseWriter, r *http.Request) {
 		type Greeting struct {
-			Text 		string `json:"text"`
-			Error		string `json:"error,omitempty"`
+			Text  string `json:"text"`
+			Error string `json:"error,omitempty"`
 		}
 
 		who := r.URL.Query().Get("who")

--- a/day-07/server.go
+++ b/day-07/server.go
@@ -26,8 +26,8 @@ import (
 func main() {
 	http.HandleFunc("/hello", func(w http.ResponseWriter, r *http.Request) {
 		type Greeting struct {
-			Text 		string `json:"text"`
-			Error		string `json:"error,omitempty"`
+			Text  string `json:"text"`
+			Error string `json:"error,omitempty"`
 		}
 
 		who := r.URL.Query().Get("who")

--- a/day-08/main.go
+++ b/day-08/main.go
@@ -15,19 +15,20 @@ package main
 
 import (
 	"net/http"
+
 	"github.com/gin-gonic/gin"
 )
 
 func main() {
-  r := gin.Default()
+	r := gin.Default()
 
-  r.GET("/hello/:name", func(c *gin.Context) {
-    c.JSON(http.StatusOK, gin.H{
-      "message":  "Hello, " + c.Param("name"),
-    })
-  })
+	r.GET("/hello/:name", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{
+			"message": "Hello, " + c.Param("name"),
+		})
+	})
 
-  r.Run()
+	r.Run()
 }
 
 /*

--- a/day-09/main.go
+++ b/day-09/main.go
@@ -13,25 +13,25 @@ import "fmt"
 
 // Answer is just a struct used to demonstrate pointers
 type Answer struct {
-  value int
+	value int
 }
 
 func main() {
-  answer := Answer{value: 42}
-  answerAgain := answer
-  answer.value = 43
+	answer := Answer{value: 42}
+	answerAgain := answer
+	answer.value = 43
 
-  fmt.Println("Wihout pointers, things get passed by value")
+	fmt.Println("Wihout pointers, things get passed by value")
 
-  fmt.Println(answer)        // output: {43}
-  fmt.Println(answerAgain)   // output: {42} (surprise, JS and Java folks!)
+	fmt.Println(answer)      // output: {43}
+	fmt.Println(answerAgain) // output: {42} (surprise, JS and Java folks!)
 
-  fmt.Println("You want to pass by reference? Use pointers")
+	fmt.Println("You want to pass by reference? Use pointers")
 
 	pAnswer := &answer
-  answer.value = 44
-  fmt.Println(answer)        // output: {44}
-	fmt.Println(*pAnswer)      // output: {44}   (whew!)
+	answer.value = 44
+	fmt.Println(answer)   // output: {44}
+	fmt.Println(*pAnswer) // output: {44}   (whew!)
 }
 
 /*

--- a/day-10/main.go
+++ b/day-10/main.go
@@ -1,11 +1,11 @@
 package main
 
 import (
-	"log"
 	"day-10/pkg/jpclient"
+	"log"
 )
 
-// a simple proxy server for: 
+// a simple proxy server for:
 // http://jsonplaceholder.typicode.com/todos/{id}
 func main() {
 	client := jpclient.NewClient()
@@ -22,13 +22,13 @@ func main() {
 
 /*
 EXPLANATION:
-- line 5:  
+- line 5:
 If your go.mod file defines the current package as "day-10",
 and your package is inside a directory called pkg, the package
 can be imported as "day-10/pkg/<packagename>".
 
-- line 10: 
-The Go way to construct structs is using a package level 
+- line 10:
+The Go way to construct structs is using a package level
 constructor function, usually named packagename.NewObjectName().
 DON'T use structs to group functions like you do in Java!
 Use packages to group functions.


### PR DESCRIPTION
Used `goimports -w **/**/*.go` for fixing imports and formatting code in
the same style as gofmt.

Thanks for sharing this repository with the community. Figured we resolve formatting so newcomers can begin learning with proper formatting.